### PR TITLE
docs: add project documentation and claude config

### DIFF
--- a/.claude/rules/COMMANDS.md
+++ b/.claude/rules/COMMANDS.md
@@ -1,0 +1,93 @@
+# Command Patterns
+
+## Structure
+
+```
+{plugin}/commands/{name}.md
+```
+
+Commands are slash-invoked workflows that expand into prompts.
+
+## Frontmatter
+
+```yaml
+---
+description: Action-oriented one-liner (shown in /help)
+argument-hint: [what user provides, or omit if no args]
+---
+```
+
+## Template
+
+```markdown
+---
+description: Systematic debugging with root cause investigation
+argument-hint: [bug description or error message]
+---
+
+# Command Title
+
+Brief framing of what this command does.
+
+## The Framework / Process
+
+Numbered steps or framework summary.
+
+## Context
+
+$ARGUMENTS
+
+---
+
+Load the {skill-name} skill and begin by:
+1. First action
+2. Second action
+3. Third action
+
+{Key constraint or philosophy reminder}
+```
+
+## Key Elements
+
+**$ARGUMENTS**: Replaced with user input after command name
+**Skill loading**: Commands should load skills for methodology
+**Clear kickoff**: End with concrete first steps to take
+
+## Command vs Skill vs Agent
+
+| Component | Invocation | Purpose |
+|-----------|------------|---------|
+| Command | `/name args` | Entry point, expands to prompt |
+| Skill | Skill tool | Methodology and patterns |
+| Agent | Task tool | Autonomous execution |
+
+Commands are lightweight entry points that load skills.
+
+## Examples
+
+**Simple command** (`/debug`):
+- Takes error/bug as argument
+- Loads debugging skill
+- Starts investigation process
+
+**Analysis command** (`/simplify`):
+- Takes proposed solution as argument
+- Loads challenge-complexity skill
+- Returns structured analysis
+
+**Discovery command** (`/patternify`):
+- Optional hint argument
+- Loads patternify skill
+- Scans conversation for patterns
+
+## Naming Conventions
+
+- Verb-based: `/debug`, `/simplify`, `/pathfind`
+- Action-oriented: what user wants to happen
+- Kebab-case for multi-word: `/skill-check`
+
+## Anti-Patterns
+
+- Command that doesn't load a skill (embed methodology in skill instead)
+- Command with complex logic (that's an agent)
+- Command that duplicates skill content (just reference skill)

--- a/.claude/rules/FORMATTING.md
+++ b/.claude/rules/FORMATTING.md
@@ -1,0 +1,123 @@
+# Formatting Conventions
+
+## Markdown in Instructions
+
+Avoid `**bold**` and other emphasis markers in skill/instruction text unless explicitly formatting output. Claude doesn't need visual emphasis to understand importance — the words themselves convey it.
+
+**Use markdown when**: formatting actual output, examples, or user-facing content
+**Skip markdown when**: writing instructions, rules, or guidance for Claude
+
+## Concision Principle
+
+Sacrifice grammar for concision — drop articles, filler words, verbose phrases. But don't strip meaning or context. Goal is density, not minimalism. If removing a word makes the instruction ambiguous, keep it.
+
+Good: "Ask one question, wait for response"
+Bad: "Ask question wait response"
+
+## Variables and Placeholders
+
+**Variables** — all caps, no spaces, curly braces:
+- `{VARIABLE}` — concrete placeholder to be replaced
+- Examples: `{N}`, `{REASON}`, `{BAR}`, `{NAME}`, `{FILE_PATH}`
+
+**Instructional prose** — lowercase, spaces inside braces:
+- `{ description of what goes here }` — guidance for what to fill in
+- Examples: `{ question text }`, `{ why it matters }`, `{ if needed }`
+
+## XML Tags in Skills
+
+Use XML tags for structural sections in skill files:
+- `<when_to_use>` — trigger conditions
+- `<confidence>` — confidence levels/tracking
+- `<phases>` — workflow phases
+- `<workflow>` — core process loop
+- `<rules>` — always/never constraints
+- `<references>` — links to supporting docs
+
+Keep content inside tags terse. Sacrifice grammar for concision where meaning is preserved.
+
+## Indicators
+
+Prefer ASCII/Unicode over emoji for terminal output (Claude Code, CLI, interactive sessions). Emoji acceptable in docs or user-facing content where rendering is reliable.
+
+### Progress
+
+- `░` — empty (light shade)
+- `▓` — filled (medium shade)
+- Example: `▓▓▓░░` = 3/5
+- Use for confidence, completion, capacity — anything with discrete levels
+
+### Severity
+
+Escalating:
+
+- `◇` — minor/informational
+- `◆` — moderate/warning
+- `◆◆` — severe/blocking
+- Use for pushback, risk, alerts, uncertainty levels
+
+### Caveats
+
+- `△` — incomplete/uncertain (warning triangle U+25B3)
+- **Mid-stream**: `△` + description — flags issue for immediate attention
+- **At delivery**: `△ Caveats` — summary section of gaps, unknowns, assumptions, concerns, deferred items
+
+### Checkmarks
+
+- `✓` — completed/decided (U+2713)
+- Use for "Decisions Made:" lists, completed items, confirmed choices
+- Example:
+  ```text
+  Decisions Made:
+  ✓ /simplify offers two modes: quick (skill) vs deep (agent)
+  ✓ Agent returns: complexity identified + alternatives + escalation level
+  ✓ Uses ◇/◆/◆◆ indicators from challenge-complexity skill
+  ```
+
+### Emphasis
+
+Append to text:
+
+- `★` — recommended/preferred
+
+## Interactive Questions
+
+For multi-option questions in skills:
+
+- Use `EnterPlanMode` — enables keyboard navigation
+- **Prose above tool**: context, "why it matters"
+- **Inside tool**: options with inline recommendation marker
+- Always include escape hatch: "5. Something else — { brief prompt }"
+
+### Inline Recommendations
+
+Mark recommended option inline with `[★]` + emphasized rationale:
+
+```text
+1. Google only [★] — simplest, highest coverage *good starting point, expand later*
+2. Google + GitHub — covers consumer and developer users
+3. Google + GitHub + Microsoft — comprehensive, more maintenance
+```
+
+Pattern: `N. Option name [★] — brief description *why recommended*`
+
+- `[★]` visually distinguishes the recommendation
+- `*italicized rationale*` provides quick reasoning
+- Everything scannable in one place
+
+## Markdown Links
+
+Use short aliases for readability. Keep paths intact.
+
+Prefer: `[filename.md](path/to/filename.md)`
+Avoid: `[path/to/filename.md](path/to/filename.md)`
+
+```text
+# Good
+- [confidence.md](references/confidence.md)
+- [FORMATTING.md](../../shared/rules/FORMATTING.md)
+
+# Avoid
+- [references/confidence.md](references/confidence.md)
+- [../../shared/rules/FORMATTING.md](../../shared/rules/FORMATTING.md)
+```

--- a/.claude/rules/PLUGINS.md
+++ b/.claude/rules/PLUGINS.md
@@ -1,0 +1,63 @@
+# Plugin Architecture
+
+## Structure
+
+```
+{plugin}/
+├── .claude-plugin/
+│   └── plugin.json      # name, version, description
+├── skills/              # SKILL.md + references/ + examples/
+├── commands/            # {name}.md slash commands
+├── agents/              # {name}.md subagents
+├── shared/
+│   └── rules/           # Common rules for this plugin
+└── README.md
+```
+
+## Marketplace Registration
+
+`/.claude-plugin/marketplace.json` at repo root:
+
+```json
+{
+  "name": "marketplace-name",
+  "plugins": [
+    { "name": "plugin-name", "source": "./path", "version": "1.0.0" }
+  ]
+}
+```
+
+## Layer Strategy
+
+**baselayer**: Universal skills (tdd, debugging, type-safety, pathfinding)
+**domain plugins**: Tool-specific (gitbutler, waymark, guardrails)
+**user overrides**: `~/.claude/` and project `.claude/`
+
+Hierarchy: user → project → plugin → baselayer
+
+## Component Decision Tree
+
+```
+Reusable pattern detected
+├── Multi-step with judgment? → SKILL
+├── Fully automatable? → COMMAND
+├── Specialized expertise? → AGENT
+└── Event-triggered? → HOOK
+```
+
+## Skill Structure
+
+```
+skills/{name}/
+├── SKILL.md           # Core methodology (<500 lines)
+├── references/        # Deep dives, patterns
+└── examples/          # Worked examples
+```
+
+Keep SKILL.md focused. Move details to references/.
+
+## Cross-Referencing
+
+Skills reference skills: `[tdd/SKILL.md](../tdd/SKILL.md)`
+Agents load skills: "Load TDD skill with Skill tool"
+Commands invoke skills: "Load the debugging skill and begin by..."

--- a/.claude/rules/SUBAGENTS.md
+++ b/.claude/rules/SUBAGENTS.md
@@ -1,0 +1,94 @@
+# Subagent Patterns
+
+## Frontmatter
+
+```yaml
+---
+name: agent-name
+version: 1.0.0
+description: |
+  One-line purpose. Second line expands.
+
+  <example>
+  Context: When this applies
+  user: "User message"
+  assistant: "Response explaining agent delegation"
+  </example>
+---
+```
+
+3-4 examples covering: typical use, edge case, verb triggers.
+
+## Core Sections
+
+```markdown
+# {Agent Name} Agent
+
+One paragraph identity statement.
+
+## Core Identity
+
+**Role**: What this agent does
+**Scope**: Boundaries of responsibility
+**Philosophy**: Guiding principle
+
+## Skill Loading Hierarchy
+
+1. User preferences (CLAUDE.md, rules/) — ALWAYS override
+2. Project context (existing patterns)
+3. Skill defaults as fallback
+
+## Available Skills
+
+List skills agent can load with:
+- **When to load**: trigger conditions
+- **What it provides**: capability
+- **Output format**: expected deliverable
+
+## Routing / Decision Tree
+
+```text
+User asks about X → Load skill Y
+User wants to Z → Load skill W
+```
+
+## Responsibilities
+
+Numbered steps or categorized duties.
+
+## Quality Checklist
+
+Verification before delivery.
+
+## Communication
+
+Starting/during/completing patterns.
+
+## Edge Cases
+
+How to handle ambiguity, conflicts, missing context.
+```
+
+## Design Principles
+
+**Generalist over specialist**: Few agents (5-7) loading many skills
+**Router pattern**: Agents detect task type, load appropriate skill
+**Skill holds methodology**: Agent orchestrates, skill executes
+**User prefs win**: Hierarchy always checked before skill defaults
+
+## Our Agents
+
+| Agent | Verbs | Loads |
+|-------|-------|-------|
+| developer | build, fix, implement, refactor | tdd, type-safety, debugging |
+| reviewer | review, critique, check, audit | fresh-eyes-review, expertise-* |
+| analyst | investigate, research, explore | research, pathfinding, patternify |
+| specialist | deploy, configure, CI/CD | domain-specific skills |
+| tester | test, validate, verify, prove | scenario-testing, tdd |
+
+## Anti-Patterns
+
+- Embedding methodology in agent (put in skill instead)
+- One agent per skill (use generalist + dynamic loading)
+- Skipping user preference check
+- Hardcoding tool/model constraints (inherit instead)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root `.claude-plugin/marketplace.json` lists every published plugin; keep it in sync when adding or renaming entries.
+- Plugin folders: `baselayer/`, `claude-dev/`, `guardrails/`, `gitbutler/`, `waymark/`. Each holds its own `.claude-plugin/plugin.json` plus `skills/`, `commands/`, and (where needed) `agents/` or `templates/`.
+- The TypeScript package with code you can build/test today is `guardrails/` (`src/` for logic, `hooks/` for integrations, `node_modules/` vendored for reproducibility). Tests live beside sources as `*.test.ts`.
+- Docs live with their plugin (e.g., `claude-dev/README.md`, `baselayer/README.md`); keep user-facing instructions close to the code that implements them.
+
+## Build, Test, and Development Commands
+- Use Bun everywhere. From a plugin directory (e.g., `guardrails/`):
+  - `bun install` — restore deps (typically already vendored).
+  - `bun run typecheck` — strict `tsc --noEmit` for API correctness.
+  - `bun run lint` / `bun run format` — Biome lint/format for style parity.
+  - `bun test` — run Bun tests; target files with `bun test src/core/*.test.ts`.
+- Local plugin validation: `/plugin marketplace add .` then `/plugin install <plugin>@outfitter` to exercise changes inside Claude Code.
+
+## Coding Style & Naming Conventions
+- TypeScript, `type`/`interface` first, prefer named exports; avoid default exports.
+- Formatting is Biome-driven (2-space indent, single quotes default); never hand-format—run `bun run format` before pushing.
+- Files and commands use `kebab-case`; tests mirror source names with `.test.ts` suffix. Keep schemas and types in `types.ts` and re-export via package entrypoints.
+
+## Testing Guidelines
+- Add or update `*.test.ts` next to the code you change; favor fast, deterministic cases over golden snapshots.
+- Cover new branches and failure modes (invalid config, missing files, CLI misuse). If you change schema validation, assert both pass and fail paths.
+- Run `bun test` plus `bun run typecheck` before submitting; include the command outputs in your PR checklist.
+
+## Commit & Pull Request Guidelines
+- Trunk-based: `main` stays releasable; feature branches live <3 days and are opened as PRs immediately with feature flags guarding incomplete work.
+- Branch names: `feat/<area>/<slug>` or `fix/<issue-id>`; avoid merge commits—rebase/squash only.
+- Use Graphite: start with `gt log`, stage changes, `gt create -m "feat: concise title"`, then `gt submit --no-interactive` to push the stack.
+- PRs: concise summary, linked issue if present, tests run (list commands), screenshots or sample CLI output when behavior changes. Lockfiles (`bun.lockb`) are regenerated, not hand-edited.
+
+## Security & Configuration
+- Never commit secrets or tokens; prefer `.env` per environment and keep them out of version control.
+- Marketplace and plugin JSON are authoritative; validate updates before merging to prevent breaking installs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is the **Outfitter Marketplace** - a collection of Claude Code plugins for developers. The repository hosts multiple plugins that can be installed individually.
+
+## Commands
+
+### Plugin installation (via Claude Code)
+
+```bash
+/plugin marketplace add outfitter-dev/agents  # Add marketplace
+/plugin install <plugin-name>@outfitter       # Install a plugin
+```
+
+## Architecture
+
+### Plugin Structure
+
+Each plugin follows Claude Code's plugin structure with a `.claude-plugin/plugin.json` manifest:
+
+```
+<plugin-name>/
+├── .claude-plugin/
+│   └── plugin.json       # Plugin manifest (name, version, hooks, commands)
+├── agents/               # Custom agents (markdown files)
+├── commands/             # Slash commands (markdown files)
+├── skills/               # Skills with SKILL.md entry points
+├── hooks/                # Event hooks (TypeScript for complex logic)
+└── README.md
+```
+
+### Available Plugins
+
+| Plugin | Purpose |
+|--------|---------|
+| **baselayer** | Core development methodology: TDD, debugging, type safety, architecture, research |
+| **claude-dev** | Authoring Claude Code plugins, marketplaces, and configuration |
+| **gitbutler** | GitButler virtual branch workflows for parallel development |
+
+## Working with Skills
+
+Skills are markdown-based instruction sets that guide agent behavior for specific tasks.
+
+### Finding Skills
+
+```bash
+# List all skills in the repo
+find . -name "SKILL.md" -not -path "*/node_modules/*"
+
+# Skills live under each plugin
+baselayer/skills/     # TDD, debugging, pathfinding, etc.
+claude-dev/skills/    # Plugin authoring, marketplace setup
+gitbutler/skills/     # Version control workflows
+```
+
+### Loading Skills into Context
+
+To use a skill, read the `SKILL.md` file into context. Skills use **progressive disclosure**:
+
+1. **Start with SKILL.md** - Contains YAML frontmatter (name, description, triggers) plus the core workflow
+2. **Load references on demand** - `references/` subdirectory has deep-dive docs
+3. **Check examples** - `examples/` or `EXAMPLES.md` for concrete patterns
+
+```bash
+# Example: load the pathfinding skill
+cat baselayer/skills/pathfinding/SKILL.md
+
+# If you need more detail on confidence levels
+cat baselayer/skills/pathfinding/references/confidence.md
+```
+
+### Skill Anatomy
+
+```markdown
+---
+name: Skill Name
+version: 1.0.0
+description: When to use this skill, trigger keywords
+---
+
+# Skill Name
+
+<when_to_use>
+Conditions that should trigger this skill
+</when_to_use>
+
+<workflow>
+Step-by-step process
+</workflow>
+
+<rules>
+ALWAYS: mandatory behaviors
+NEVER: prohibited actions
+</rules>
+
+<references>
+Links to supporting docs
+</references>
+```
+
+### Formatting Conventions
+
+Skills and output should follow `.claude/rules/FORMATTING.md`:
+- Use Unicode indicators (`░▓` for progress, `◇◆` for severity, `△` for caveats)
+- Variables in `{ALL_CAPS}`, instructional prose in `{ lowercase with spaces }`
+- XML tags for structural sections (`<workflow>`, `<rules>`, etc.)
+- Avoid markdown emphasis in instructions; save it for user-facing output
+
+## Marketplace Configuration
+
+The root `.claude-plugin/marketplace.json` defines available plugins with source locations and metadata. Plugins can reference local directories (`./plugin-name`) or external GitHub repos.
+
+## Conventions
+
+- **Bun** is the runtime and package manager for TypeScript projects
+- **Biome** for linting and formatting
+- Skills should follow formatting conventions in `.claude/rules/FORMATTING.md`


### PR DESCRIPTION
Add CLAUDE.md with repository overview, plugin structure, and conventions.
Add AGENTS.md with agent documentation.
Add .claude/rules/ with formatting, plugin, and subagent patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>