### PR TITLE
refactor(claude-dev): restructure skill commands

### DIFF
--- a/claude-dev/commands/skill/create.md
+++ b/claude-dev/commands/skill/create.md
@@ -168,7 +168,7 @@ When all phases complete:
 
 ## Example Session
 
-**User:** `/claude-dev:skill-create github-issues`
+**User:** `/claude-dev:skill:create github-issues`
 
 **Assistant:**
 1. Asks clarifying questions about GitHub issues skill
@@ -204,5 +204,5 @@ skill-archetypes/
 
 ## Related Commands
 
-- `/claude-dev:skill-validate` - Validate skill structure (future)
-- `/claude-dev:skill-package` - Package skill for distribution (future)
+- `/claude-dev:skill:validate` - Validate skill structure (future)
+- `/claude-dev:skill:package` - Package skill for distribution (future)


### PR DESCRIPTION
Replace skill-create.md with modular skill/ command directory.
Reorganize skill authoring workflow into smaller focused commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>